### PR TITLE
Disable alert dismiss by tapping outside the alert box in android

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ export default class RatingRequestor {
       _config.title,
       _config.message,
       buttons,
+      {cancelable: false},
     );
   }
 


### PR DESCRIPTION
Disables 'dismiss alert by tapping outside the alert box in android' functionality which is the default behaviour of `Alert` component in android. This change doesn't affect iOS.